### PR TITLE
Add date-picker-calendar test case (interaction-level selection-grid ARIA)

### DIFF
--- a/test_cases/date-picker-calendar/examples/bad-aria-pressed-no-grid.html
+++ b/test_cases/date-picker-calendar/examples/bad-aria-pressed-no-grid.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Date picker — anti-pattern: aria-pressed toggle buttons, no grid</title>
+  <script id="a11y-assertions" type="application/json">{
+    "assertions": {
+      "Calendar day grid is present and openable": "pass",
+      "Each calendar day has an accessible name": "pass",
+      "Day cells expose grid or listbox selection semantics": "fail",
+      "Selection uses aria-selected, not aria-pressed": "fail",
+      "Exactly one day is marked selected after a day is chosen": "fail",
+      "Arrow keys move focus within the day grid": "fail"
+    }
+  }</script>
+</head>
+<body>
+  <div class="date-picker">
+    <label for="appt2">Appointment date</label>
+    <input id="appt2" type="text" readonly aria-label="Appointment date">
+    <button type="button" id="open2">Choose date</button>
+
+    <h2>June 2026</h2>
+    <!-- ANTI-PATTERN: day cells are toggle buttons using aria-pressed, no grid
+         semantics, and no arrow-key navigation (Tab only). -->
+    <div id="grid2"></div>
+  </div>
+
+  <button type="submit">Submit</button>
+
+  <script>
+    const grid = document.getElementById('grid2');
+    for (let day = 1; day <= 28; day++) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.setAttribute('aria-pressed', day === 5 ? 'true' : 'false');
+      btn.textContent = String(day);
+      btn.style.width = '2em';
+      btn.addEventListener('click', () => {
+        grid.querySelectorAll('button').forEach((b) => b.setAttribute('aria-pressed', 'false'));
+        btn.setAttribute('aria-pressed', 'true');
+        document.getElementById('appt2').value = 'June ' + day + ', 2026';
+      });
+      grid.appendChild(btn);
+    }
+  </script>
+</body>
+</html>

--- a/test_cases/date-picker-calendar/examples/good-grid-aria-selected.html
+++ b/test_cases/date-picker-calendar/examples/good-grid-aria-selected.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Date picker — conformant grid with aria-selected</title>
+  <script id="a11y-assertions" type="application/json">{
+    "assertions": {
+      "Calendar day grid is present and openable": "pass",
+      "Each calendar day has an accessible name": "pass",
+      "Day cells expose grid or listbox selection semantics": "pass",
+      "Selection uses aria-selected, not aria-pressed": "pass",
+      "Exactly one day is marked selected after a day is chosen": "pass",
+      "Arrow keys move focus within the day grid": "pass"
+    }
+  }</script>
+</head>
+<body>
+  <div class="date-picker">
+    <label for="appt">Appointment date</label>
+    <input id="appt" type="text" readonly aria-label="Appointment date">
+    <button type="button" id="open" aria-haspopup="grid" aria-expanded="true">Choose date</button>
+
+    <h2 id="cal-heading">June 2026</h2>
+    <div role="grid" aria-labelledby="cal-heading" id="grid"></div>
+  </div>
+
+  <button type="submit">Submit</button>
+
+  <script>
+    const grid = document.getElementById('grid');
+    const days = 28, perRow = 7;
+    let selected = 5;
+    for (let r = 0; r < days / perRow; r++) {
+      const row = document.createElement('div');
+      row.setAttribute('role', 'row');
+      for (let c = 0; c < perRow; c++) {
+        const day = r * perRow + c + 1;
+        const cell = document.createElement('div');
+        cell.setAttribute('role', 'gridcell');
+        cell.setAttribute('tabindex', day === selected ? '0' : '-1');
+        cell.setAttribute('aria-label', 'June ' + day + ', 2026');
+        cell.setAttribute('aria-selected', day === selected ? 'true' : 'false');
+        cell.textContent = String(day);
+        cell.style.display = 'inline-block';
+        cell.style.width = '2em';
+        row.appendChild(cell);
+      }
+      grid.appendChild(row);
+    }
+
+    const cells = () => Array.from(grid.querySelectorAll('[role="gridcell"]'));
+
+    function select(cell) {
+      cells().forEach((c) => {
+        c.setAttribute('aria-selected', 'false');
+        c.setAttribute('tabindex', '-1');
+      });
+      cell.setAttribute('aria-selected', 'true');
+      cell.setAttribute('tabindex', '0');
+      document.getElementById('appt').value = cell.getAttribute('aria-label');
+      cell.focus();
+    }
+
+    grid.addEventListener('click', (e) => {
+      const cell = e.target.closest('[role="gridcell"]');
+      if (cell) select(cell);
+    });
+
+    grid.addEventListener('keydown', (e) => {
+      const all = cells();
+      const i = all.indexOf(document.activeElement);
+      if (i < 0) return;
+      let next = i;
+      if (e.key === 'ArrowRight') next = i + 1;
+      else if (e.key === 'ArrowLeft') next = i - 1;
+      else if (e.key === 'ArrowDown') next = i + perRow;
+      else if (e.key === 'ArrowUp') next = i - perRow;
+      else return;
+      e.preventDefault();
+      if (next >= 0 && next < all.length) {
+        all[i].setAttribute('tabindex', '-1');
+        all[next].setAttribute('tabindex', '0');
+        all[next].focus();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/test_cases/date-picker-calendar/prompt.yaml
+++ b/test_cases/date-picker-calendar/prompt.yaml
@@ -1,0 +1,9 @@
+name: Date Picker Calendar
+base_prompt: |
+  Build a page with a date picker. It has a text input labeled "Appointment date" and a button that opens a calendar showing the days of the current month in a grid. The user can pick a single day by clicking it or by moving with the arrow keys and pressing Enter. The chosen day is visibly highlighted and its date is filled into the input.
+common_requirements:
+  - Wrap the date picker in a div with class "date-picker".
+  - Show the current month and year as a heading above the day grid.
+  - Render the days of the month as a grid the user can move through with the keyboard.
+  - Include a submit button.
+dimensions:

--- a/test_cases/date-picker-calendar/test.js
+++ b/test_cases/date-picker-calendar/test.js
@@ -1,0 +1,217 @@
+/**
+ * Date picker calendar accessibility assertions.
+ *
+ * Focus: the interaction-level ARIA contract for calendar day grids that a
+ * static axe-core scan does not cover. The centerpiece is that a chosen day is
+ * exposed as *selected* (aria-selected) rather than *pressed* (aria-pressed):
+ * aria-pressed announces "button pressed", which misrepresents a calendar day,
+ * whereas a day in a grid/listbox is a selection and must use aria-selected.
+ * Also checks grid/listbox role semantics, programmatic selected state, and
+ * keyboard navigability of the grid.
+ *
+ * Grounded in the "aria-pressed-in-selection-context" and
+ * "option-missing-aria-selected" anti-patterns (WAI-ARIA 1.2; WCAG SC 4.1.2;
+ * Class III — Widget Role Contract Violation).
+ */
+
+const normalizeText = (value) => (value || '').toString().replace(/[\s ]+/g, ' ').trim();
+
+const DAY_NUMBER = /^([1-9]|[12]\d|3[01])$/;
+const SELECTION_CELL_ROLES = ['gridcell', 'option', 'row'];
+const SELECTION_CONTAINER_ROLES = ['grid', 'listbox', 'table'];
+
+// Tag and collect candidate "day cells" inside the date picker so later
+// assertions can re-locate a specific cell via [data-arr-day-index].
+const collectDayCells = async (page) =>
+    page.evaluate(() => {
+        const scopeEl = document.querySelector('.date-picker') || document.body;
+        const candidates = new Set();
+
+        // Explicit selection / grid semantics.
+        scopeEl
+            .querySelectorAll('[role="gridcell"], [role="option"], [aria-selected], [aria-pressed]')
+            .forEach((el) => candidates.add(el));
+
+        // Clickable elements whose label is a day-of-month number (1–31).
+        scopeEl.querySelectorAll('button, td, [tabindex], [role="button"]').forEach((el) => {
+            const text = (el.textContent || '').trim();
+            if (/^([1-9]|[12]\d|3[01])$/.test(text)) candidates.add(el);
+        });
+
+        return [...candidates].map((el, i) => {
+            el.setAttribute('data-arr-day-index', String(i));
+            let name = el.getAttribute('aria-label') || '';
+            const labelledBy = el.getAttribute('aria-labelledby');
+            if (!name && labelledBy) {
+                name = labelledBy
+                    .split(/\s+/)
+                    .map((id) => {
+                        const node = document.getElementById(id);
+                        return node ? node.textContent : '';
+                    })
+                    .join(' ');
+            }
+            if (!name) name = el.textContent || '';
+
+            const container = el.closest('[role="grid"], [role="listbox"], [role="table"], table');
+            return {
+                index: i,
+                name: name.replace(/[\s ]+/g, ' ').trim(),
+                role: el.getAttribute('role') || el.tagName.toLowerCase(),
+                ariaSelected: el.getAttribute('aria-selected'),
+                ariaPressed: el.getAttribute('aria-pressed'),
+                ariaCurrent: el.getAttribute('aria-current'),
+                containerRole: container ? container.getAttribute('role') || container.tagName.toLowerCase() : null,
+                tag: el.tagName.toLowerCase(),
+                tabindex: el.getAttribute('tabindex'),
+            };
+        });
+    });
+
+// Best effort: open the calendar by clicking a non-submit trigger in the picker.
+const openCalendar = async (page) => {
+    const triggers = page.locator('.date-picker button, .date-picker [role="button"], .date-picker input');
+    const count = await triggers.count().catch(() => 0);
+    for (let i = 0; i < count; i += 1) {
+        const el = triggers.nth(i);
+        const text = normalizeText(await el.innerText().catch(() => ''));
+        const type = (await el.getAttribute('type').catch(() => '')) || '';
+        if (/submit/i.test(text) || type === 'submit') continue;
+        await el.click().catch(() => {});
+        await page.waitForTimeout(50);
+        const cells = await collectDayCells(page);
+        if (cells.length > 0) return cells;
+    }
+    return collectDayCells(page);
+};
+
+module.exports.run = async ({ page, assert, utils }) => {
+    const reload = async () => {
+        if (utils && typeof utils.reload === 'function') {
+            await utils.reload();
+        } else {
+            await page.reload();
+        }
+        await page.waitForTimeout(50);
+    };
+
+    let dayCells = await openCalendar(page);
+
+    await assert('Calendar day grid is present and openable', async () => {
+        if (dayCells.length === 0) {
+            return { pass: false, message: 'No calendar day cells were found after opening the date picker' };
+        }
+        return { pass: true, message: `Found ${dayCells.length} day cells` };
+    });
+
+    await assert('Each calendar day has an accessible name', async () => {
+        if (dayCells.length === 0) return { pass: false, message: 'No day cells to evaluate' };
+        const unnamed = dayCells.filter((cell) => !normalizeText(cell.name));
+        if (unnamed.length === 0) return { pass: true, message: 'All day cells have accessible names' };
+        return { pass: false, message: `${unnamed.length} day cell(s) have no accessible name` };
+    });
+
+    await assert('Day cells expose grid or listbox selection semantics', async () => {
+        if (dayCells.length === 0) return { pass: false, message: 'No day cells to evaluate' };
+        const ok = dayCells.filter(
+            (cell) =>
+                SELECTION_CELL_ROLES.includes(cell.role) ||
+                (cell.containerRole && SELECTION_CONTAINER_ROLES.includes(cell.containerRole)),
+        );
+        if (ok.length >= Math.ceil(dayCells.length / 2)) {
+            return { pass: true, message: 'Day cells sit within a grid/listbox with selection roles' };
+        }
+        return {
+            pass: false,
+            message:
+                'Day cells are not exposed as gridcell/option within a grid or listbox; ' +
+                'assistive technology cannot interpret them as selectable days',
+        };
+    });
+
+    // Centerpiece: aria-selected (selection) vs aria-pressed (toggle button).
+    await assert('Selection uses aria-selected, not aria-pressed', async () => {
+        if (dayCells.length === 0) return { pass: false, message: 'No day cells to evaluate' };
+        const pressed = dayCells.filter((cell) => cell.ariaPressed !== null && cell.ariaPressed !== undefined);
+        if (pressed.length > 0) {
+            return {
+                pass: false,
+                message:
+                    `${pressed.length} day cell(s) use aria-pressed. A calendar day is a selection within a grid, ` +
+                    'so it must use aria-selected — aria-pressed makes screen readers announce "button pressed" ' +
+                    'instead of "selected".',
+            };
+        }
+        const hasSelected = dayCells.some((cell) => cell.ariaSelected !== null && cell.ariaSelected !== undefined);
+        if (!hasSelected) {
+            return {
+                pass: false,
+                message: 'No day cell exposes aria-selected; selection state is not communicated to assistive technology',
+            };
+        }
+        return { pass: true, message: 'Day cells communicate selection with aria-selected and avoid aria-pressed' };
+    });
+
+    await assert('Exactly one day is marked selected after a day is chosen', async () => {
+        let selected = dayCells.filter((cell) => String(cell.ariaSelected) === 'true');
+        if (selected.length !== 1) {
+            const target =
+                dayCells.find(
+                    (cell) =>
+                        DAY_NUMBER.test(normalizeText(cell.name)) ||
+                        cell.role === 'gridcell' ||
+                        cell.role === 'option',
+                ) || dayCells[0];
+            if (target) {
+                await page.locator(`[data-arr-day-index="${target.index}"]`).click().catch(() => {});
+                await page.waitForTimeout(50);
+                let after = await collectDayCells(page);
+                if (after.length === 0) {
+                    await openCalendar(page);
+                    after = await collectDayCells(page);
+                }
+                dayCells = after;
+                selected = dayCells.filter((cell) => String(cell.ariaSelected) === 'true');
+            }
+        }
+        if (selected.length === 1) {
+            return { pass: true, message: 'Exactly one day is programmatically marked selected' };
+        }
+        return { pass: false, message: `Expected exactly one day with aria-selected="true"; found ${selected.length}` };
+    });
+
+    await assert('Arrow keys move focus within the day grid', async () => {
+        await reload();
+        const cells = await openCalendar(page);
+        if (cells.length < 2) {
+            return { pass: false, message: 'Not enough day cells to test keyboard navigation' };
+        }
+        const start = cells.find((cell) => cell.tabindex !== null) || cells[0];
+        const locator = page.locator(`[data-arr-day-index="${start.index}"]`);
+        await locator.focus().catch(() => {});
+        const before = await page.evaluate(
+            () => document.activeElement && document.activeElement.getAttribute('data-arr-day-index'),
+        );
+        await locator.press('ArrowRight').catch(() => {});
+        await page.waitForTimeout(30);
+        let after = await page.evaluate(
+            () => document.activeElement && document.activeElement.getAttribute('data-arr-day-index'),
+        );
+        if (after === before) {
+            await page.keyboard.press('ArrowDown').catch(() => {});
+            await page.waitForTimeout(30);
+            after = await page.evaluate(
+                () => document.activeElement && document.activeElement.getAttribute('data-arr-day-index'),
+            );
+        }
+        if (after && after !== before) {
+            return { pass: true, message: 'Arrow keys move focus between day cells' };
+        }
+        return {
+            pass: false,
+            message: 'Arrow keys did not move focus within the day grid; keyboard users cannot navigate the calendar',
+        };
+    });
+
+    return {};
+};


### PR DESCRIPTION
## Summary
Adds a new test case, `test_cases/date-picker-calendar/`, that evaluates a date-picker
calendar widget. It focuses on the interaction-level ARIA contract for **selection grids**
— semantics that a static axe-core pass does not catch on its own.

## Motivation
The existing test cases cover forms and disclosure patterns, but there is no calendar /
date-picker case. Date grids are a common pattern models frequently get subtly wrong in
ways axe-core alone does not flag:
- **`aria-pressed` vs `aria-selected`.** Generated calendars often mark the chosen day with
  `aria-pressed` (toggle-button state) instead of `aria-selected` (selection state). Both
  attributes are individually valid, so axe-core does not report it — but a screen reader
  announces "button pressed" instead of "selected". A role-contract defect only a semantics
  assertion catches.
- **Missing grid/listbox semantics.** Day cells are often plain buttons with no
  `role="gridcell"`/`role="grid"`, so AT cannot present them as selectable days.
- **No keyboard navigation.** Calendars frequently ship without arrow-key movement.

These map to WAI-ARIA 1.2, the WAI-ARIA APG grid pattern, and WCAG 2.1 SC 4.1.2.

## What this adds
- **`prompt.yaml`** — a neutral product spec (does not state the ARIA answer).
- **`test.js`** — six assertions, following the existing
  `module.exports.run = async ({ page, assert, utils })` convention:
  1. Day grid present and openable
  2. Each day cell has an accessible name
  3. Day cells expose grid/listbox selection semantics
  4. **Selection uses `aria-selected`, not `aria-pressed`**
  5. Exactly one day marked selected after a choice
  6. Arrow keys move focus within the grid

DOM discovery is self-contained; the only `utils` call (`reload`) is guarded.

## Validation
Ran `test.js` with Playwright against a conformant calendar (all six pass) and an
anti-pattern calendar using `aria-pressed` toggle buttons with no grid semantics or
keyboard nav (assertions 3–6 fail with specific messages).

## Checklist
- [x] I have signed the Microsoft CLA
- [ x] I ran the repository's evaluation harness locally
- [ x] The new case follows the existing `test_cases/` conventions